### PR TITLE
Allow puppet-strings 2.x and kafo 2.x

### DIFF
--- a/kafo_module_lint.gemspec
+++ b/kafo_module_lint.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'kafo', '>= 1.0.4', '< 2'
   spec.add_dependency 'kafo_parsers'
-  spec.add_dependency 'puppet-strings', '>= 0.99', '< 2'
+  spec.add_dependency 'puppet-strings', '>= 0.99', '< 3'
 end

--- a/kafo_module_lint.gemspec
+++ b/kafo_module_lint.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_dependency 'kafo', '>= 1.0.4', '< 2'
+  spec.add_dependency 'kafo', '>= 1.0.4', '< 3'
   spec.add_dependency 'kafo_parsers'
   spec.add_dependency 'puppet-strings', '>= 0.99', '< 3'
 end


### PR DESCRIPTION
Version 2.0 is a major bump because it dropped the minimum Ruby and and Puppet versions. Otherwise it is compatible.